### PR TITLE
remove double bookkeeping of selected dominoes (editing)

### DIFF
--- a/DominoPlanner.Usage/ProjectCanvas.cs
+++ b/DominoPlanner.Usage/ProjectCanvas.cs
@@ -108,13 +108,6 @@ namespace DominoPlanner.Usage
         }
         public static readonly StyledProperty<bool> SelectionDomainVisibleProperty = AvaloniaProperty.Register<ProjectCanvas, bool>(nameof(SelectionDomainVisible));
 
-        public AvaloniaList<int> SelectedDominoes
-        {
-            get { return (AvaloniaList<int>)GetValue(SelectedDominoesProperty); }
-            set { SetValue(SelectedDominoesProperty, value); }
-        }
-        public static readonly StyledProperty<AvaloniaList<int>> SelectedDominoesProperty = AvaloniaProperty.Register<ProjectCanvas, AvaloniaList<int>>(nameof(SelectedDominoes));
-
         public SKBitmap SourceImage
         {
             get { return GetValue(SourceImageProperty); }

--- a/DominoPlanner.Usage/UserControls/View/EditProject.xaml
+++ b/DominoPlanner.Usage/UserControls/View/EditProject.xaml
@@ -246,7 +246,6 @@
                                           ShiftX="{Binding DisplaySettingsTool.HorizontalOffset}"
                                           ShiftY="{Binding DisplaySettingsTool.VerticalOffset}"
                                           Zoom="{Binding DisplaySettingsTool.ZoomValue, Mode=TwoWay}"
-                                          SelectedDominoes="{Binding SelectedDominoes}"
                                           SelectedBorderColor="{Binding DisplaySettingsTool.SelectedColor}"
                                           UnselectedBorderColor="{Binding DisplaySettingsTool.BorderColor}"
                                           SelectionDomain="{Binding SelectionTool.CurrentSelectionDomain.SelectionShape}"

--- a/DominoPlanner.Usage/UserControls/ViewModel/EditingToolsVM.cs
+++ b/DominoPlanner.Usage/UserControls/ViewModel/EditingToolsVM.cs
@@ -240,7 +240,7 @@ namespace DominoPlanner.Usage.UserControls.ViewModel
         }
         public void InvertSelectionOperation()
         {
-            var current = parent.selectedDominoes.ToList();
+            var current = parent.GetSelectedDominoes();
             var n = Enumerable.Range(0, parent.dominoTransfer.Length).Except(current).ToList();
             Select(current, false);
             Select(n, true);


### PR DESCRIPTION
Does not seem to impact performance negatively. (Makes sense, iterating over an array of <100.000 elements is not that expensive compared to all the drawing operations). Now there should never be a mismatch between dominoes selected on screen and those that operations are performed on.